### PR TITLE
chore: release v0.60.4

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.60.3",
+  "version": "0.60.4",
   "scripts": {
     "bench": "node run.mjs"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "scripts": {
     "docs:dev": "vitepress dev",

--- a/examples/vue-cli4/package.json
+++ b/examples/vue-cli4/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "scripts": {
     "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",

--- a/examples/vue-cli5/package.json
+++ b/examples/vue-cli5/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "scripts": {
     "dev": "vue-cli-service serve",

--- a/interactive/package.json
+++ b/interactive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "interactive",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "scripts": {
     "build": "nuxi prepare && esno scripts/prepare.ts && nuxi generate",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/monorepo",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "packageManager": "pnpm@8.6.8",
   "scripts": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/astro",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "UnoCSS integration for Astro",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/autocomplete",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Autocomplete utils for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/cli",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "CLI for UnoCSS",
   "author": {
     "name": "Johann Schopplich",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/config",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Config loader for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/core",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The instant on-demand Atomic CSS engine.",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/eslint-config",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "ESLint config for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/eslint-plugin",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "ESLint plugin for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/extractor-arbitrary-variants/package.json
+++ b/packages/extractor-arbitrary-variants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/extractor-arbitrary-variants",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Extractor arbitrary variants for utilities",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/extractor-mdc/package.json
+++ b/packages/extractor-mdc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/extractor-mdc",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "UnoCSS extractor for MDC",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/extractor-pug/package.json
+++ b/packages/extractor-pug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/extractor-pug",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "UnoCSS extractor for Pug",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/extractor-svelte/package.json
+++ b/packages/extractor-svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/extractor-svelte",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "UnoCSS extractor for Svelte",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/inspector",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The inspector UI for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/nuxt",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Nuxt module for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/postcss",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "PostCSS plugin for UnoCSS",
   "author": "sibbng <sibbngheid@gmail.com>",
   "license": "MIT",

--- a/packages/preset-attributify/package.json
+++ b/packages/preset-attributify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-attributify",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Attributify preset for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-icons/package.json
+++ b/packages/preset-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-icons",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Pure CSS Icons for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-legacy-compat/package.json
+++ b/packages/preset-legacy-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocss/preset-legacy-compat",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Collections of legacy compatibility utilities.",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-mini/package.json
+++ b/packages/preset-mini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-mini",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The minimal preset for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-rem-to-px/package.json
+++ b/packages/preset-rem-to-px/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-rem-to-px",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Convert all rem to px in utils",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-tagify/package.json
+++ b/packages/preset-tagify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-tagify",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Tagify preset for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-typography/package.json
+++ b/packages/preset-typography/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-typography",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Typography preset for UnoCSS",
   "author": "Jeff Yang",
   "license": "MIT",

--- a/packages/preset-uno/package.json
+++ b/packages/preset-uno/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-uno",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The default preset for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-web-fonts/package.json
+++ b/packages/preset-web-fonts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-web-fonts",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Web Fonts support for Uno CSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/preset-wind/package.json
+++ b/packages/preset-wind/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/preset-wind",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Tailwind / Windi CSS compact preset for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/reset",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Collection of CSS resetting",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/rule-utils/package.json
+++ b/packages/rule-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/rule-utils",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Utilities for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/runtime",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "CSS-in-JS Runtime for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/scope/package.json
+++ b/packages/scope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/scope",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Placeholder for UnoCSS scope import",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/shared-common/package.json
+++ b/packages/shared-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/shared-common",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "dependencies": {
     "@unocss/core": "workspace:*"

--- a/packages/shared-docs/package.json
+++ b/packages/shared-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/shared-docs",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "dependencies": {
     "@unocss/autocomplete": "workspace:*",

--- a/packages/shared-integration/package.json
+++ b/packages/shared-integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/shared-integration",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "dependencies": {
     "@unocss/core": "workspace:*",

--- a/packages/svelte-scoped/package.json
+++ b/packages/svelte-scoped/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/svelte-scoped",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Use UnoCSS in a modular fashion with styles being stored only in the Svelte component they are used in: Vite plugin for apps, Svelte preprocessor for component libraries",
   "author": "Jacob Bowdoin",
   "license": "MIT",

--- a/packages/transformer-attributify-jsx-babel/package.json
+++ b/packages/transformer-attributify-jsx-babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/transformer-attributify-jsx-babel",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Support valueless attributify in JSX/TSX.",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/transformer-attributify-jsx/package.json
+++ b/packages/transformer-attributify-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/transformer-attributify-jsx",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Support valueless attributify in JSX/TSX.",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/transformer-compile-class/package.json
+++ b/packages/transformer-compile-class/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/transformer-compile-class",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Compile group of classes into one class",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/transformer-directives/package.json
+++ b/packages/transformer-directives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/transformer-directives",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "UnoCSS transformer for `@apply` directive",
   "author": "hannoeru <me@hanlee.co>",
   "license": "MIT",

--- a/packages/transformer-variant-group/package.json
+++ b/packages/transformer-variant-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/transformer-variant-group",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Variant group transformer for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/unocss/package.json
+++ b/packages/unocss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unocss",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The instant on-demand Atomic CSS engine.",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/vite",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The Vite plugin for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "publisher": "antfu",
   "name": "@unocss/vscode",
   "displayName": "UnoCSS",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "description": "UnoCSS for VS Code",
   "license": "MIT",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unocss/webpack",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "The Webpack plugin for UnoCSS",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "private": true,
   "scripts": {
     "dev": "vite --open",


### PR DESCRIPTION
I noticed that unocss has released version 0.60.4, so the documentation should also need to be updated
I'm not sure if I modified it correctly. Please correct me if it's wrong.

![image](https://github.com/cn-docs/unocss/assets/65441198/b9a77e07-e685-44fc-985a-b1cae635602c)

![image](https://github.com/cn-docs/unocss/assets/65441198/32d5bac5-668c-41df-adf7-272a1ff7e046)
